### PR TITLE
Fix incorrect def. value of DJANGO_SETTING_MODULE

### DIFF
--- a/rfdocset/settings/__init__.py
+++ b/rfdocset/settings/__init__.py
@@ -3,7 +3,10 @@
 import os
 import sys
 
-settings_file = os.environ.get("DJANGO_SETTINGS_MODULE", "rfdocset.settings.dev")
+settings_file = os.environ.get("DJANGO_SETTINGS_MODULE")
+# Default value of DJANGO_SETTINGS_MODULE is set in rfdocset/wsgi.py
+if settings_file == "rfdocset.settings":
+    settings_file = "rfdocset.settings.dev"
 
 
 class SettingsModuleWrapper(object):


### PR DESCRIPTION
Without this patch, `manage.py` complains about missing `SECRET_KEY`. `rfdocet/settings/dev.py` needs to be created manually though, but at least I don't need to set neither `$SECRET_KEY` nor `$DJANGO_SETTINGS_MODULE` when launching `manage.py`.