### PR TITLE
Remove default SECRET_KEY

### DIFF
--- a/rfdocset/settings/base.py
+++ b/rfdocset/settings/base.py
@@ -35,7 +35,7 @@ def get_env_variable(var, fail_to=None):
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '{V*b0~n`+7m*J4G&u~6lgKjD%QRefKb:UX;#<9lm5ZEgW-NW*7'
+SECRET_KEY = ''
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Each installation of this project must have its own SECRET_KEY.

(from https://github.com/andriyko/rfdocs/pull/4#issuecomment-121415102)